### PR TITLE
Add Phase 8.5 Unicode sigil notation layer to Vibe

### DIFF
--- a/tests/test_grammar_spec.py
+++ b/tests/test_grammar_spec.py
@@ -11,3 +11,5 @@ def test_grammar_is_primary_definition_contains_new_blocks() -> None:
     assert "experimental.tesla.victory.layer" in GRAMMAR
     assert "agentora" in GRAMMAR
     assert "agentception" in GRAMMAR
+    assert "sigil:" in GRAMMAR
+    assert "sigil_temporal:" in GRAMMAR

--- a/tests/test_sigil_phase85.py
+++ b/tests/test_sigil_phase85.py
@@ -1,0 +1,81 @@
+import json
+from pathlib import Path
+
+from vibe.cli import main
+from vibe.ir import ast_to_ir
+from vibe.lexer import lex
+from vibe.parser import ParseError, parse_source
+from vibe.proof import build_proof_artifact
+from vibe.verifier import verify
+
+
+def test_lexer_emits_sigil_tokens() -> None:
+    tokens = lex("sigil:\n  pulse: ⟨Φ⟩⟢⟨∇⟩⟢⟨Ω⟩\n")
+    assert [t.kind for t in tokens] == ["BLOCK", "SIGIL"]
+
+
+def test_parser_accepts_sigil_blocks() -> None:
+    src = Path("vibe/examples/sigil_temporal.vibe").read_text(encoding="utf-8")
+    program = parse_source(src)
+    assert len(program.sigils) == 2
+    assert len(program.sigil_sequences) == 1
+
+
+def test_parser_rejects_bad_sigil_expression() -> None:
+    src = """
+intent BadSigil:
+  goal: "x"
+  inputs:
+    a: symbol
+  outputs:
+    b: symbol
+sigil:
+  broken: Φ->Ω
+emit python
+"""
+    try:
+        parse_source(src)
+    except ParseError as exc:
+        assert "Invalid sigil expression" in str(exc)
+    else:
+        raise AssertionError("expected ParseError")
+
+
+def test_ir_contains_canonical_sigil_graph() -> None:
+    src = Path("vibe/examples/sigil_collective.vibe").read_text(encoding="utf-8")
+    ir = ast_to_ir(parse_source(src))
+    assert ir.module.sigil_graph["kind"] == "SigilGraph"
+    assert ir.module.sigil_graph["edges"]
+
+
+def test_verifier_surfaces_sigil_obligations() -> None:
+    src = Path("vibe/examples/sigil_temporal.vibe").read_text(encoding="utf-8")
+    ir = ast_to_ir(parse_source(src))
+    result = verify(ir, "def sigil_temporal(signal):\n    return signal\n")
+    obligation_ids = {row["obligation_id"] for row in result.sigil_obligations}
+    assert "sigil.temporal.sequence.coherent" in obligation_ids
+    assert "sigil.bridge.threshold.passed" in obligation_ids
+
+
+def test_cli_sigil_validate_and_inspect_json(capsys, tmp_path) -> None:
+    src = Path("vibe/examples/sigil_basic.vibe")
+    case = tmp_path / "sigil_basic.vibe"
+    case.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+
+    assert main(["sigil-validate", str(case), "--report", "json"]) == 0
+    validate_payload = json.loads(capsys.readouterr().out)
+    assert validate_payload["ok"] is True
+
+    assert main(["sigil-inspect", str(case), "--report", "json"]) == 0
+    inspect_payload = json.loads(capsys.readouterr().out)
+    assert inspect_payload["sigil_graph"]["kind"] == "SigilGraph"
+
+
+def test_proof_artifact_includes_sigil_evidence() -> None:
+    source_path = Path("vibe/examples/sigil_basic.vibe")
+    source_text = source_path.read_text(encoding="utf-8")
+    ir = ast_to_ir(parse_source(source_text))
+    result = verify(ir, "def sigil_basic(source):\n    return source\n")
+    artifact = build_proof_artifact(source_path, source_text, ir, result, emitted_blocked=not result.passed)
+    assert "sigils" in artifact
+    assert artifact["sigils"]["summary"]["sigil_count"] >= 1

--- a/vibe/ast.py
+++ b/vibe/ast.py
@@ -124,6 +124,28 @@ class DelegationDecl:
 
 
 @dataclass(slots=True)
+class SigilExpression:
+    name: str
+    form: str
+    source: str
+    operation: str
+    target: str
+    coupled_with: str | None = None
+
+
+@dataclass(slots=True)
+class SigilTemporalStep:
+    name: str
+    expression: SigilExpression
+
+
+@dataclass(slots=True)
+class SigilTemporalSequence:
+    name: str
+    steps: list[SigilTemporalStep] = field(default_factory=list)
+
+
+@dataclass(slots=True)
 class Program:
     intent: IntentBlock
     preserve: list[PreserveRule] = field(default_factory=list)
@@ -143,3 +165,5 @@ class Program:
     orchestrations: list[OrchestrateBlock] = field(default_factory=list)
     delegations: list[DelegationDecl] = field(default_factory=list)
     domain_profile: str | None = None
+    sigils: list[SigilExpression] = field(default_factory=list)
+    sigil_sequences: list[SigilTemporalSequence] = field(default_factory=list)

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -734,6 +734,77 @@ def _inspect_proof(path: Path) -> int:
     return 0
 
 
+def _sigil_validate(path: Path, report: ReportMode) -> int:
+    try:
+        source = path.read_text(encoding="utf-8")
+        ir = ast_to_ir(parse_source(source))
+    except Exception as exc:
+        if report == "json":
+            import json
+
+            print(json.dumps({"ok": False, "error": str(exc)}, indent=2, sort_keys=True))
+        else:
+            print(f"sigil-validate failed: {exc}")
+        return 1
+    summary = dict(ir.module.sigil_summary)
+    ok = bool(summary.get("syntax_valid", True)) and not any(
+        not bool(summary.get(k, True))
+        for k in (
+            "structure_composable",
+            "state_transition_allowed",
+            "epsilon_nonzero",
+            "temporal_sequence_coherent",
+            "bridge_threshold_passed",
+        )
+    )
+    if report == "json":
+        import json
+
+        print(json.dumps({"ok": ok, "summary": summary, "issues": list(ir.module.sigil_issues)}, indent=2, sort_keys=True))
+    else:
+        print("=== Vibe Sigil Validate ===")
+        print(f"path: {path}")
+        print(f"ok: {ok}")
+        print(f"summary: {summary}")
+        print(f"issues: {ir.module.sigil_issues}")
+    return 0 if ok else 1
+
+
+def _sigil_inspect(path: Path, report: ReportMode) -> int:
+    try:
+        source = path.read_text(encoding="utf-8")
+        ir = ast_to_ir(parse_source(source))
+    except Exception as exc:
+        if report == "json":
+            import json
+
+            print(json.dumps({"error": str(exc)}, indent=2, sort_keys=True))
+        else:
+            print(f"sigil-inspect failed: {exc}")
+        return 1
+    if report == "json":
+        import json
+
+        print(
+            json.dumps(
+                {
+                    "sigil_graph": ir.module.sigil_graph,
+                    "sigil_summary": ir.module.sigil_summary,
+                    "sigil_issues": ir.module.sigil_issues,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        print("=== Vibe Sigil Inspect ===")
+        print(f"path: {path}")
+        print(f"sigil_graph: {ir.module.sigil_graph}")
+        print(f"sigil_summary: {ir.module.sigil_summary}")
+        print(f"sigil_issues: {ir.module.sigil_issues}")
+    return 0
+
+
 def _monitor_eval(proof_path: Path, events_path: Path, report: ReportMode, show_events: bool = False) -> int:
     try:
         proof = load_proof_artifact(proof_path)
@@ -1603,6 +1674,12 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Fail with non-zero exit if merged result contains any intent_conflicts",
     )
+    sg = sub.add_parser("sigil-validate", help="Validate sigil notation obligations in a .vibe file")
+    sg.add_argument("path", type=Path)
+    sg.add_argument("--report", choices=["human", "json"], default="human")
+    si = sub.add_parser("sigil-inspect", help="Inspect lowered canonical SigilGraph IR for a .vibe file")
+    si.add_argument("path", type=Path)
+    si.add_argument("--report", choices=["human", "json"], default="human")
 
     return parser
 
@@ -1674,6 +1751,10 @@ def main(argv: list[str] | None = None) -> int:
         )
     if args.command == "inspect-proof":
         return _inspect_proof(args.path)
+    if args.command == "sigil-validate":
+        return _sigil_validate(args.path, args.report)
+    if args.command == "sigil-inspect":
+        return _sigil_inspect(args.path, args.report)
     if args.command in {"monitor-eval", "runtime-check"}:
         return _monitor_eval(args.proof_path, args.events_path, args.report, show_events=args.show_events)
     if args.command == "init":

--- a/vibe/examples/sigil_basic.vibe
+++ b/vibe/examples/sigil_basic.vibe
@@ -1,0 +1,9 @@
+intent SigilBasic:
+  goal: "Prototype sigil transformation"
+  inputs:
+    source: symbol
+  outputs:
+    target: symbol
+sigil:
+  seed_flow: ⟨Φ⟩⟢⟨∇⟩⟢⟨Ω⟩
+emit python

--- a/vibe/examples/sigil_collective.vibe
+++ b/vibe/examples/sigil_collective.vibe
@@ -1,0 +1,11 @@
+intent SigilCollective:
+  goal: "Compose coupling and recursive sigils"
+  inputs:
+    a: symbol
+    b: symbol
+  outputs:
+    collective: symbol
+sigil:
+  coupling: ⟨Φ⟩⟡⟨☉⟩⟢Ω
+  recurse: ⟨◉⟩⟣∇⟢⊙
+emit python

--- a/vibe/examples/sigil_temporal.vibe
+++ b/vibe/examples/sigil_temporal.vibe
@@ -1,0 +1,14 @@
+intent SigilTemporal:
+  goal: "Validate ordered temporal sigil steps"
+  inputs:
+    signal: symbol
+  outputs:
+    stabilized: symbol
+sigil:
+  warmup: ⟨◌⟩⟢⟨Φ⟩⟢⟨◉⟩
+  focus: ⟨◉⟩⟢⟨∇⟩⟢⟨◎⟩
+sigil_temporal:
+  phase_cycle:
+    step_1: ⟨◌⟩⟢⟨Φ⟩⟢⟨◉⟩
+    step_2: ⟨◉⟩⟢⟨∇⟩⟢⟨◎⟩
+emit python

--- a/vibe/grammar.py
+++ b/vibe/grammar.py
@@ -15,7 +15,7 @@ type            <- 'type' WS IDENT_PATH NEWLINE
 enum            <- 'enum' WS IDENT_PATH NEWLINE
 interface       <- 'interface' WS IDENT_PATH NEWLINE
 
-core_block      <- intent_block / preserve_block / constraint_block / bridge_block / agent_block / orchestrate_block / delegate_block / emit_stmt
+core_block      <- intent_block / preserve_block / constraint_block / bridge_block / sigil_block / sigil_temporal_block / agent_block / orchestrate_block / delegate_block / emit_stmt
 intent_block    <- 'intent' WS IDENT ':' NEWLINE INDENT intent_item+ DEDENT
 intent_item     <- goal_item / io_block
 io_block        <- ('inputs' / 'outputs') ':' NEWLINE INDENT field_decl+ DEDENT
@@ -25,6 +25,11 @@ goal_item       <- 'goal:' WS? STRING NEWLINE
 preserve_block  <- 'preserve:' NEWLINE INDENT preserve_rule+ DEDENT
 constraint_block<- 'constraint:' NEWLINE INDENT constraint_line+ DEDENT
 bridge_block    <- 'bridge:' NEWLINE INDENT bridge_setting+ DEDENT
+sigil_block     <- 'sigil:' NEWLINE INDENT sigil_decl+ DEDENT
+sigil_decl      <- IDENT ':' WS? SIGIL_EXPR NEWLINE
+sigil_temporal_block <- 'sigil_temporal:' NEWLINE INDENT sigil_temporal_decl+ DEDENT
+sigil_temporal_decl <- IDENT ':' NEWLINE INDENT sigil_step+ DEDENT
+sigil_step      <- IDENT ':' WS? SIGIL_EXPR NEWLINE
 agent_block     <- 'agent' WS IDENT ':' NEWLINE INDENT agent_item+ DEDENT
 agent_item      <- role_item / receives_item / emits_item / agent_preserve_item / agent_constraint_item
 role_item       <- 'role:' WS? STRING NEWLINE

--- a/vibe/ir.py
+++ b/vibe/ir.py
@@ -108,6 +108,22 @@ class IRAgentception:
 
 
 @dataclass(slots=True)
+class IRSigilExpression:
+    name_ref: str
+    form_ref: str
+    source_ref: str
+    operation_ref: str
+    target_ref: str
+    coupled_with_ref: str | None = None
+
+
+@dataclass(slots=True)
+class IRSigilTemporalSequence:
+    name_ref: str
+    step_refs: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
 class IRModule:
     module_name: str
     vibe_version_ref: str | None
@@ -125,6 +141,11 @@ class IRModule:
     tesla_layer: IRTeslaLayer | None
     agentora: IRAgentora | None
     agentception: IRAgentception | None
+    sigils: list[IRSigilExpression] = field(default_factory=list)
+    sigil_temporal_sequences: list[IRSigilTemporalSequence] = field(default_factory=list)
+    sigil_graph: dict[str, object] = field(default_factory=dict)
+    sigil_summary: dict[str, object] = field(default_factory=dict)
+    sigil_issues: list[dict[str, object]] = field(default_factory=list)
     semantic_summary: dict[str, object] = field(default_factory=dict)
     semantic_issues: list[dict[str, object]] = field(default_factory=list)
     effect_summary: dict[str, object] = field(default_factory=dict)
@@ -475,6 +496,45 @@ def ast_to_ir(program: Program) -> IR:
             stop_when_ref=b.const("variant", "literal", a.stop_when),
         )
 
+    sigils: list[IRSigilExpression] = []
+    graph_nodes: set[str] = set()
+    graph_edges: list[dict[str, str]] = []
+    for sigil in program.sigils:
+        name_ref = b.const("symbol", "identifier", sigil.name)
+        form_ref = b.const("symbol", "identifier", sigil.form)
+        source_ref = b.const("symbol", "identifier", sigil.source)
+        operation_ref = b.const("symbol", "identifier", sigil.operation)
+        target_ref = b.const("symbol", "identifier", sigil.target)
+        coupled_with_ref = b.const("symbol", "identifier", sigil.coupled_with) if sigil.coupled_with else None
+        sigils.append(
+            IRSigilExpression(
+                name_ref=name_ref,
+                form_ref=form_ref,
+                source_ref=source_ref,
+                operation_ref=operation_ref,
+                target_ref=target_ref,
+                coupled_with_ref=coupled_with_ref,
+            )
+        )
+        graph_nodes.update([sigil.source, sigil.target, sigil.operation])
+        graph_edges.append({"kind": "transform", "source": sigil.source, "operation": sigil.operation, "target": sigil.target})
+        if sigil.coupled_with:
+            graph_nodes.add(sigil.coupled_with)
+            graph_edges.append({"kind": "couple", "source": sigil.source, "target": sigil.coupled_with})
+
+    temporal_sequences: list[IRSigilTemporalSequence] = []
+    temporal_payload: list[dict[str, object]] = []
+    for seq in program.sigil_sequences:
+        seq_name_ref = b.const("symbol", "identifier", seq.name)
+        step_refs: list[str] = []
+        steps_payload: list[dict[str, str]] = []
+        for step in seq.steps:
+            step_ref = b.const("symbol", "identifier", step.name)
+            step_refs.append(step_ref)
+            steps_payload.append({"name": step.name, "sigil": step.expression.name})
+        temporal_sequences.append(IRSigilTemporalSequence(name_ref=seq_name_ref, step_refs=step_refs))
+        temporal_payload.append({"name": seq.name, "steps": steps_payload})
+
     vibe_version_ref = b.const("string", "literal", program.vibe_version) if program.vibe_version else None
     imports_refs = [b.const("symbol", "identifier", v) for v in program.imports]
     modules_refs = [b.const("symbol", "identifier", v) for v in program.modules]
@@ -499,6 +559,14 @@ def ast_to_ir(program: Program) -> IR:
         tesla_layer=tesla_layer,
         agentora=agentora,
         agentception=agentception,
+        sigils=sigils,
+        sigil_temporal_sequences=temporal_sequences,
+        sigil_graph={
+            "kind": "SigilGraph",
+            "nodes": sorted(graph_nodes),
+            "edges": sorted(graph_edges, key=lambda row: (row["kind"], row["source"], row["target"])),
+            "temporal_sequences": temporal_payload,
+        },
         agent_graph={
             "agents": [
                 {
@@ -534,6 +602,29 @@ def ast_to_ir(program: Program) -> IR:
         },
         active_domain_profile=program.domain_profile or "general",
     )
+    bridge_lookup = {x.key: x.value for x in program.bridge}
+    epsilon_floor = float(bridge_lookup.get("epsilon_floor", DEFAULT_EPSILON_FLOOR))
+    allowed_states = {"◌": 0, "◉": 1, "◎": 2, "⊙": 3, "⊚": 4}
+    state_transition_allowed = True
+    for s in program.sigils:
+        if s.source in allowed_states and s.target in allowed_states and allowed_states[s.source] > allowed_states[s.target]:
+            state_transition_allowed = False
+            break
+    module.sigil_summary = {
+        "sigil_count": len(program.sigils),
+        "temporal_sequence_count": len(program.sigil_sequences),
+        "syntax_valid": True,
+        "structure_composable": all(bool(s.operation) for s in program.sigils),
+        "state_transition_allowed": state_transition_allowed,
+        "epsilon_nonzero": epsilon_floor > 0.0,
+        "temporal_sequence_coherent": all(len(seq.steps) > 0 for seq in program.sigil_sequences),
+        "bridge_threshold_passed": float(bridge_lookup.get("measurement_safe_ratio", DEFAULT_MEASUREMENT_SAFE_RATIO)) >= 0.5,
+    }
+    module.sigil_issues = [
+        {"issue_id": f"sigil.{k}", "message": f"sigil check `{k}` failed"}
+        for k, v in module.sigil_summary.items()
+        if k not in {"sigil_count", "temporal_sequence_count"} and not bool(v)
+    ]
     ir = IR(module=module)
     from .semantic_types import annotate_semantic_types
 
@@ -663,6 +754,13 @@ def validate_ir(ir: IR) -> None:
             refs.extend(_obj_dict(a).values())
     if ir.module.agentception:
         refs.extend(_obj_dict(ir.module.agentception).values())
+    for s in ir.module.sigils:
+        refs.extend([s.name_ref, s.form_ref, s.source_ref, s.operation_ref, s.target_ref])
+        if s.coupled_with_ref:
+            refs.append(s.coupled_with_ref)
+    for seq in ir.module.sigil_temporal_sequences:
+        refs.append(seq.name_ref)
+        refs.extend(seq.step_refs)
 
     for ref in refs:
         if ref not in ir.module.values:
@@ -691,6 +789,11 @@ def serialize_ir(ir: IR) -> str:
             {"agents": [_obj_dict(a) for a in ir.module.agentora.agents]} if ir.module.agentora else None
         ),
         "agentception": _obj_dict(ir.module.agentception) if ir.module.agentception else None,
+        "sigils": [_obj_dict(s) for s in ir.module.sigils],
+        "sigil_temporal_sequences": [_obj_dict(s) for s in ir.module.sigil_temporal_sequences],
+        "sigil_graph": dict(ir.module.sigil_graph),
+        "sigil_summary": dict(ir.module.sigil_summary),
+        "sigil_issues": list(ir.module.sigil_issues),
         "semantic_summary": dict(ir.module.semantic_summary),
         "semantic_issues": list(ir.module.semantic_issues),
         "effect_summary": dict(ir.module.effect_summary),

--- a/vibe/lexer.py
+++ b/vibe/lexer.py
@@ -4,6 +4,25 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+SIGIL_GLYPHS = {
+    "Φ",
+    "∴",
+    "☉",
+    "∇",
+    "Ω",
+    "⟨",
+    "⟩",
+    "⟡",
+    "⟐",
+    "⟢",
+    "⟣",
+    "◌",
+    "◉",
+    "◎",
+    "⊙",
+    "⊚",
+}
+
 
 @dataclass(slots=True)
 class Token:
@@ -28,8 +47,11 @@ def lex(source: str) -> list[Token]:
         if indent % 2 != 0:
             raise ValueError(f"Line {line_no}: indentation must use multiples of 2 spaces")
         stripped = raw.strip()
+        has_sigil = any(ch in SIGIL_GLYPHS for ch in stripped)
         if stripped.endswith(":"):
             tokens.append(Token("BLOCK", stripped[:-1], line_no, indent))
+        elif has_sigil:
+            tokens.append(Token("SIGIL", stripped, line_no, indent))
         else:
             tokens.append(Token("LINE", stripped, line_no, indent))
     return tokens

--- a/vibe/parser.py
+++ b/vibe/parser.py
@@ -18,6 +18,9 @@ from .ast import (
     IntentBlock,
     PreserveRule,
     Program,
+    SigilExpression,
+    SigilTemporalSequence,
+    SigilTemporalStep,
     TeslaArcTower,
     TeslaBreathCycle,
     TeslaLifeRay,
@@ -41,6 +44,9 @@ BARE_PRESERVE_RULES = {
     "provenance retained",
     "stable normalization method",
 }
+PRIMARY_SIGIL_GENERATORS = {"Φ", "∴", "☉", "∇", "Ω"}
+SIGIL_OPERATORS = {"⟨", "⟩", "⟡", "⟐", "⟢", "⟣"}
+SIGIL_STATES = {"◌", "◉", "◎", "⊙", "⊚"}
 
 
 class ParseError(ValueError):
@@ -238,6 +244,59 @@ def _parse_agentception(inner: str) -> AgentceptionBlock:
     )
 
 
+def _strip_sigil_term(raw: str) -> str:
+    out = raw.strip()
+    if out.startswith("⟨") and out.endswith("⟩"):
+        return out[1:-1].strip()
+    return out
+
+
+def _validate_sigil_term(term: str, line_no: int) -> None:
+    if not term:
+        raise ParseError("Sigil expression terms must be non-empty", line_no, 1)
+    if " " in term and not any(ch in SIGIL_STATES for ch in term):
+        raise ParseError(f"Sigil term `{term}` must be atomic (no whitespace)", line_no, 1)
+
+
+def _parse_sigil_expr(name: str, expr: str, line_no: int) -> SigilExpression:
+    basic = re.fullmatch(r"⟨([^⟨⟩]+)⟩⟢⟨([^⟨⟩]+)⟩⟢⟨([^⟨⟩]+)⟩", expr)
+    if basic:
+        source, operation, target = (_strip_sigil_term(v) for v in basic.groups())
+        _validate_sigil_term(source, line_no)
+        _validate_sigil_term(operation, line_no)
+        _validate_sigil_term(target, line_no)
+        return SigilExpression(name=name, form="basic", source=source, operation=operation, target=target)
+
+    coupling = re.fullmatch(r"⟨([^⟨⟩]+)⟩⟡⟨([^⟨⟩]+)⟩⟢(.+)", expr)
+    if coupling:
+        source, coupled, target_raw = coupling.groups()
+        source, coupled, target = _strip_sigil_term(source), _strip_sigil_term(coupled), _strip_sigil_term(target_raw)
+        for term in (source, coupled, target):
+            _validate_sigil_term(term, line_no)
+        return SigilExpression(
+            name=name,
+            form="coupling",
+            source=source,
+            operation="⟡",
+            target=target,
+            coupled_with=coupled,
+        )
+
+    recursive = re.fullmatch(r"⟨([^⟨⟩]+)⟩⟣([^⟢]+)⟢(.+)", expr)
+    if recursive:
+        source, operation, target_raw = recursive.groups()
+        source, operation, target = _strip_sigil_term(source), _strip_sigil_term(operation), _strip_sigil_term(target_raw)
+        for term in (source, operation, target):
+            _validate_sigil_term(term, line_no)
+        return SigilExpression(name=name, form="recursive", source=source, operation=operation, target=target)
+
+    raise ParseError(
+        "Invalid sigil expression. Expected basic `⟨s⟩⟢⟨op⟩⟢⟨t⟩`, coupling `⟨a⟩⟡⟨b⟩⟢target`, or recursive `⟨a⟩⟣op⟢target`",
+        line_no,
+        1,
+    )
+
+
 def parse_source(source: str) -> Program:
     """Parse raw source text into an AST Program using the formal grammar."""
 
@@ -286,6 +345,8 @@ def parse_source(source: str) -> Program:
     agents: list[AgentGraphAgent] = []
     orchestrations: list[OrchestrateBlock] = []
     delegations: list[DelegationDecl] = []
+    sigils: list[SigilExpression] = []
+    sigil_sequences: list[SigilTemporalSequence] = []
     emit_target = "python"
 
     while i < len(tokens):
@@ -352,6 +413,43 @@ def parse_source(source: str) -> Program:
                 key, value = [x.strip() for x in cur.text.split("=", 1)]
                 bridge.append(BridgeSetting(key=key, value=value))
                 i += 1
+            continue
+        if tk.text == "sigil:":
+            i += 1
+            while i < len(tokens) and tokens[i].indent > 0:
+                cur = tokens[i]
+                if cur.indent != 2 or ":" not in cur.text:
+                    raise ParseError("Malformed sigil declaration; expected `name: expression`", cur.line, cur.indent + 1)
+                name, expr = [x.strip() for x in cur.text.split(":", 1)]
+                if not name:
+                    raise ParseError("Sigil declaration requires a name", cur.line, 1)
+                sigils.append(_parse_sigil_expr(name, expr, cur.line))
+                i += 1
+            continue
+
+        if tk.text == "sigil_temporal:":
+            i += 1
+            while i < len(tokens) and tokens[i].indent > 0:
+                head = tokens[i]
+                if head.indent != 2 or not head.text.endswith(":"):
+                    raise ParseError(
+                        "Malformed sigil_temporal sequence header; expected `sequence_name:`",
+                        head.line,
+                        head.indent + 1,
+                    )
+                seq_name = head.text[:-1].strip()
+                i += 1
+                steps: list[SigilTemporalStep] = []
+                while i < len(tokens) and tokens[i].indent > 2:
+                    step = tokens[i]
+                    if step.indent != 4 or ":" not in step.text:
+                        raise ParseError("Malformed sigil temporal step; expected `step: expression`", step.line, step.indent + 1)
+                    step_name, expr = [x.strip() for x in step.text.split(":", 1)]
+                    steps.append(SigilTemporalStep(name=step_name, expression=_parse_sigil_expr(step_name, expr, step.line)))
+                    i += 1
+                if not steps:
+                    raise ParseError("sigil_temporal sequence requires at least one step", head.line, 1)
+                sigil_sequences.append(SigilTemporalSequence(name=seq_name, steps=steps))
             continue
 
         if tk.text.startswith("agent ") and tk.text.endswith(":"):
@@ -471,6 +569,8 @@ def parse_source(source: str) -> Program:
         orchestrations=orchestrations,
         delegations=delegations,
         domain_profile=domain_profile,
+        sigils=sigils,
+        sigil_sequences=sigil_sequences,
     )
 
     if tesla_raw is not None:

--- a/vibe/proof.py
+++ b/vibe/proof.py
@@ -48,6 +48,7 @@ REQUIRED_FIELDS = {
     "scientific_simulation",
     "legal_compliance",
     "genomics",
+    "sigils",
     "self_hosting",
     "notes",
 }
@@ -229,6 +230,12 @@ def build_proof_artifact(
             "target_metadata": result.genomics_target_metadata,
             "metadata_privacy_summary": result.metadata_privacy_summary,
             "workflow_provenance_metadata": result.workflow_provenance_metadata,
+        },
+        "sigils": {
+            "summary": result.sigil_summary,
+            "issues": result.sigil_issues,
+            "obligations": result.sigil_obligations,
+            "graph": dict(ir.module.sigil_graph),
         },
         "self_hosting": {
             "self_hosting_enabled": result.self_hosting_enabled,

--- a/vibe/report.py
+++ b/vibe/report.py
@@ -85,6 +85,11 @@ def verify_contract_payload(
         "sha256": proof_sha256,
     }
     payload["external_obligation_providers"] = list(getattr(result, "external_obligation_providers", []))
+    payload["sigils"] = {
+        "summary": dict(getattr(result, "sigil_summary", {})),
+        "issues": list(getattr(result, "sigil_issues", [])),
+        "obligations": list(getattr(result, "sigil_obligations", [])),
+    }
     payload["legacy_report"] = legacy
     return payload
 
@@ -315,6 +320,14 @@ def render_report(
             f"  genomics_target_metadata: {result.genomics_target_metadata}",
             f"  metadata_privacy_summary: {result.metadata_privacy_summary}",
             f"  workflow_provenance_metadata: {result.workflow_provenance_metadata}",
+        ]
+    )
+    lines.extend(
+        [
+            "sigils:",
+            f"  sigil_summary: {result.sigil_summary}",
+            f"  sigil_issues: {result.sigil_issues}",
+            f"  sigil_obligations: {result.sigil_obligations}",
         ]
     )
     lines.extend(

--- a/vibe/verifier.py
+++ b/vibe/verifier.py
@@ -254,6 +254,9 @@ class VerificationResult:
     genomics_target_metadata: dict[str, object] = field(default_factory=dict)
     metadata_privacy_summary: dict[str, object] = field(default_factory=dict)
     workflow_provenance_metadata: dict[str, object] = field(default_factory=dict)
+    sigil_summary: dict[str, object] = field(default_factory=dict)
+    sigil_issues: list[dict[str, object]] = field(default_factory=list)
+    sigil_obligations: list[dict[str, object]] = field(default_factory=list)
     self_hosting_enabled: bool = False
     compiler_spec_path: str | None = None
     self_bridge_score: float | None = None
@@ -414,6 +417,19 @@ class HeuristicObligationBackend:
             elif kind == "delegation_not_enabled":
                 status = "not_applicable"
                 evidence = "agentception disabled"
+            elif kind.startswith("sigil_"):
+                evidence_map = {
+                    "sigil_syntax_valid": "syntax_valid",
+                    "sigil_structure_composable": "structure_composable",
+                    "sigil_state_transition_allowed": "state_transition_allowed",
+                    "sigil_epsilon_nonzero": "epsilon_nonzero",
+                    "sigil_temporal_sequence_coherent": "temporal_sequence_coherent",
+                    "sigil_bridge_threshold_passed": "bridge_threshold_passed",
+                }
+                key = evidence_map.get(kind, "")
+                observed = bool(context.observed_bools.get(f"sigil.{key}", False))
+                status = "satisfied" if observed else "violated"
+                evidence = f"{key}={observed}"
 
             evaluated.append(
                 VerificationObligation(
@@ -546,6 +562,24 @@ class SMTObligationBackend:
                 status = "not_applicable"
                 evidence = "not applicable in current program state"
                 solver_evaluated += 1
+            elif kind.startswith("sigil_"):
+                evidence_map = {
+                    "sigil_syntax_valid": "sigil.syntax_valid",
+                    "sigil_structure_composable": "sigil.structure_composable",
+                    "sigil_state_transition_allowed": "sigil.state_transition_allowed",
+                    "sigil_epsilon_nonzero": "sigil.epsilon_nonzero",
+                    "sigil_temporal_sequence_coherent": "sigil.temporal_sequence_coherent",
+                    "sigil_bridge_threshold_passed": "sigil.bridge_threshold_passed",
+                }
+                evidence_key = evidence_map.get(kind, "")
+                obs = context.observed_bools.get(evidence_key)
+                if obs is None:
+                    deferred += 1
+                    evidence = f"deferred: no observed boolean for `{evidence_key}`"
+                else:
+                    status = "satisfied" if obs else "violated"
+                    evidence = f"solver-evaluated: {evidence_key}={obs}"
+                    solver_evaluated += 1
             else:
                 deferred += 1
 
@@ -887,6 +921,29 @@ def generate_normalized_obligations(ir: IR) -> list[NormalizedObligation]:
             )
         )
 
+    if int(ir.module.sigil_summary.get("sigil_count", 0)) > 0 or int(ir.module.sigil_summary.get("temporal_sequence_count", 0)) > 0:
+        sigil_requirements = [
+            ("sigil.syntax.valid", "sigil syntax is valid", "sigil_syntax_valid"),
+            ("sigil.structure.composable", "sigil structure is composable", "sigil_structure_composable"),
+            ("sigil.state.transition.allowed", "sigil state transitions are allowed", "sigil_state_transition_allowed"),
+            ("sigil.epsilon.nonzero", "sigil epsilon surface is non-zero", "sigil_epsilon_nonzero"),
+            ("sigil.temporal.sequence.coherent", "sigil temporal sequence is coherent", "sigil_temporal_sequence_coherent"),
+            ("sigil.bridge.threshold.passed", "sigil bridge threshold is passed", "sigil_bridge_threshold_passed"),
+        ]
+        for obligation_id, description, kind in sigil_requirements:
+            obligations.append(
+                NormalizedObligation(
+                    obligation_id=obligation_id,
+                    category="sigil",
+                    description=description,
+                    source_location=None,
+                    subject_ref="sigil.graph",
+                    expected_predicate={"kind": kind},
+                    severity="error",
+                    critical=True,
+                )
+            )
+
     return obligations
 
 
@@ -1126,6 +1183,76 @@ def _build_result(
         )
         for row in domain_obligation_rows
     ]
+    sigil_rows = []
+    if int(ir.module.sigil_summary.get("sigil_count", 0)) > 0 or int(ir.module.sigil_summary.get("temporal_sequence_count", 0)) > 0:
+        sigil_rows = [
+            {
+                "obligation_id": "sigil.syntax.valid",
+                "category": "sigil",
+                "description": "sigil syntax is valid",
+                "source_location": None,
+                "status": "satisfied" if bool(ir.module.sigil_summary.get("syntax_valid", False)) else "violated",
+                "evidence": f"syntax_valid={bool(ir.module.sigil_summary.get('syntax_valid', False))}",
+                "critical": True,
+            },
+            {
+                "obligation_id": "sigil.structure.composable",
+                "category": "sigil",
+                "description": "sigil structure is composable",
+                "source_location": None,
+                "status": "satisfied" if bool(ir.module.sigil_summary.get("structure_composable", False)) else "violated",
+                "evidence": f"structure_composable={bool(ir.module.sigil_summary.get('structure_composable', False))}",
+                "critical": True,
+            },
+            {
+                "obligation_id": "sigil.state.transition.allowed",
+                "category": "sigil",
+                "description": "sigil state transitions are allowed",
+                "source_location": None,
+                "status": "satisfied" if bool(ir.module.sigil_summary.get("state_transition_allowed", False)) else "violated",
+                "evidence": f"state_transition_allowed={bool(ir.module.sigil_summary.get('state_transition_allowed', False))}",
+                "critical": True,
+            },
+            {
+                "obligation_id": "sigil.epsilon.nonzero",
+                "category": "sigil",
+                "description": "sigil epsilon surface is non-zero",
+                "source_location": None,
+                "status": "satisfied" if bool(ir.module.sigil_summary.get("epsilon_nonzero", False)) else "violated",
+                "evidence": f"epsilon_nonzero={bool(ir.module.sigil_summary.get('epsilon_nonzero', False))}",
+                "critical": True,
+            },
+            {
+                "obligation_id": "sigil.temporal.sequence.coherent",
+                "category": "sigil",
+                "description": "sigil temporal sequence is coherent",
+                "source_location": None,
+                "status": "satisfied" if bool(ir.module.sigil_summary.get("temporal_sequence_coherent", False)) else "violated",
+                "evidence": f"temporal_sequence_coherent={bool(ir.module.sigil_summary.get('temporal_sequence_coherent', False))}",
+                "critical": True,
+            },
+            {
+                "obligation_id": "sigil.bridge.threshold.passed",
+                "category": "sigil",
+                "description": "sigil bridge threshold is passed",
+                "source_location": None,
+                "status": "satisfied" if bool(ir.module.sigil_summary.get("bridge_threshold_passed", False)) else "violated",
+                "evidence": f"bridge_threshold_passed={bool(ir.module.sigil_summary.get('bridge_threshold_passed', False))}",
+                "critical": True,
+            },
+        ]
+    sigil_obligations = [
+        VerificationObligation(
+            obligation_id=str(row["obligation_id"]),
+            category="sigil",
+            description=str(row["description"]),
+            source_location=None,
+            status=str(row["status"]),
+            evidence=str(row["evidence"]),
+            critical=True,
+        )
+        for row in sigil_rows
+    ]
     all_obligations = (
         list(obligations)
         + list(external_obligations or [])
@@ -1137,6 +1264,7 @@ def _build_result(
         + boundary_obligations
         + delegation_obligations
         + domain_obligations
+        + sigil_obligations
     )
 
     counts = _compute_obligation_counts(all_obligations)
@@ -1253,6 +1381,9 @@ def _build_result(
         genomics_target_metadata=dict(ir.module.genomics_target_metadata),
         metadata_privacy_summary=dict(ir.module.metadata_privacy_summary),
         workflow_provenance_metadata=dict(ir.module.workflow_provenance_metadata),
+        sigil_summary=dict(ir.module.sigil_summary),
+        sigil_issues=list(ir.module.sigil_issues),
+        sigil_obligations=sigil_rows,
         external_obligation_providers=list(external_provider_executions or []),
     )
 
@@ -1279,6 +1410,17 @@ def _build_observed_facts(ir: IR, metrics: _MetricSnapshot, generated_code: str)
         "inherit.preserve": bool(ir.agentception_config.get("inherit_preserve", False)),
         "preserve.epsilon": metrics.epsilon_post > metrics.epsilon_floor,
     }
+    for key in (
+        "syntax_valid",
+        "structure_composable",
+        "state_transition_allowed",
+        "epsilon_nonzero",
+        "temporal_sequence_coherent",
+        "bridge_threshold_passed",
+    ):
+        val = bool(ir.module.sigil_summary.get(key, False))
+        bool_facts[f"sigil.{key}"] = val
+        bool_facts[f"sigil.{key.replace('_', '.')}"] = val
     symbol_facts: dict[str, str] = {
         "verdict": metrics.verdict,
         "mode": str(ir.bridge_config.get("mode", "")),


### PR DESCRIPTION
### Motivation

- Introduce a bounded, first-class sigil notation extension to .vibe sources that augments Vibe without replacing core syntax and preserves the deterministic parse -> typed IR -> verify -> proof/report -> emit pipeline.
- Surface sigil intent and evidence to the verifier and proof/report JSON so sigil-specific obligations are explicit and machine-readable.

### Description

- Added AST node types `SigilExpression`, `SigilTemporalStep`, and `SigilTemporalSequence` and program-level collections for sigils and temporal sequences (vibe/ast.py). 
- Extended the lexer to recognize Unicode sigil glyphs and emit `SIGIL` tokens, and added grammar rules and parser logic to accept `sigil:` and `sigil_temporal:` blocks with deterministic parsing for basic, coupling, and recursive forms and clear parse errors for malformed expressions (vibe/lexer.py, vibe/grammar.py, vibe/parser.py). 
- Lowered sigils to canonical IR artifacts (`IRSigilExpression`, `IRSigilTemporalSequence`, and `sigil_graph` SigilGraph payload) and added deterministic sigil summary/issue computation during IR lowering (vibe/ir.py). 
- Introduced deterministic sigil verification obligations and backend wiring for six obligations (`sigil.syntax.valid`, `sigil.structure.composable`, `sigil.state.transition.allowed`, `sigil.epsilon.nonzero`, `sigil.temporal.sequence.coherent`, `sigil.bridge.threshold.passed`) and added sigil evidence into the verification result shape (vibe/verifier.py). 
- Updated proof and report surfaces to include a `sigils` section carrying summary, issues, obligations, and the lowered `SigilGraph` for machine consumption (vibe/proof.py, vibe/report.py). 
- Added CLI helpers `vibec sigil-validate <file.vibe>` and `vibec sigil-inspect <file.vibe>` for quick validation and inspection of canonical SigilGraph IR (vibe/cli.py). 
- Added three example .vibe files and a focused test suite exercising lexer, parser, IR lowering, verifier obligations, CLI JSON output, and proof artifact inclusion (vibe/examples/*.vibe, tests/test_sigil_phase85.py). 

### Testing

- Ran targeted unit tests for the sigil feature and surrounding systems with `PYTHONPATH=. pytest -q tests/test_sigil_phase85.py tests/test_parser.py tests/test_verifier.py tests/test_cli_snapshots.py tests/test_proof_artifacts.py tests/test_grammar_spec.py`, which passed when executed with the local import path set; an initial collection run without `PYTHONPATH` failed due to import path resolution (environment difference) but is environmental and not related to the changes.
- Verified no regressions in IR/SSA and examples with `PYTHONPATH=. pytest -q tests/test_ir_ssa.py tests/test_examples.py`, which passed.
- Added deterministic proof/report assertions verifying `sigils` evidence is present in generated proof JSON and that `SigilGraph` lowering is produced (tests included in the new test module).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcb601da648328870241b759e89f1f)