### PR TITLE
Relicense repository to MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,11 +1,21 @@
-Copyright (c) 2026 Michael Wave / Parallax
+MIT License
 
-GNU AFFERO GENERAL PUBLIC LICENSE
-Version 3, 19 November 2007
+Copyright (c) 2026 Michael Hughes
 
-This project is licensed under the GNU Affero General Public License v3.0 only (AGPL-3.0-only).
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-You should include the full canonical license text from:
-https://www.gnu.org/licenses/agpl-3.0.txt
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-SPDX-License-Identifier: AGPL-3.0-only
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -336,4 +336,4 @@ Near-term:
 
 ## License
 
-See `LICENSE`.
+MIT — see `LICENSE`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Vibe: intent-first programming language and compiler prototype"
 readme = "README.md"
 requires-python = ">=3.11"
 authors = [{ name = "Michael Wave / Parallax" }]
-license = "AGPL-3.0-only"
+license = "MIT"
 keywords = ["compiler", "dsl", "intent", "verification"]
 classifiers = [
   "Programming Language :: Python :: 3",

--- a/vibe/README.md
+++ b/vibe/README.md
@@ -132,3 +132,8 @@ Each verifier run prints:
 - Multiple emit targets (e.g., TypeScript).
 - Constraint solver hooks and stronger semantic checks.
 - Pluggable bridge metric calibrators for domain-specific validation.
+
+## License
+
+MIT — see LICENSE.
+


### PR DESCRIPTION
### Motivation
- Replace the repository's AGPL relicensing with the canonical MIT license text for clearer permissive distribution and consistent metadata. 
- Ensure all top-level project metadata and README references declare the same license to avoid contradictions. 
- Make a minimal, surgical change-set that preserves vendored third-party licenses and author metadata where present.

### Description
- Replaced top-level `LICENSE` with the exact canonical MIT license text and the requested copyright line `Copyright (c) 2026 Michael Hughes`.
- Updated root packaging metadata in `pyproject.toml` from `AGPL-3.0-only` to `MIT`.
- Updated `README.md` license line to `MIT — see \`LICENSE\`.`, and added a short `## License` section to `vibe/README.md` for consistency.
- Left vendored third-party code (e.g., `vscode-vibe-lsp/node_modules/`) untouched and preserved existing author metadata in `pyproject.toml` (`Michael Wave / Parallax`) to avoid altering identity information without review.

### Testing
- Ran repository scans with `rg` to locate remaining AGPL/GNU/SPDX/All-rights-reserved occurrences and confirmed no remaining project-owned matches (scan succeeded).
- Verified `license` fields with targeted searches (`pyproject.toml` and `vibe/pyproject.toml`) and confirmed they now reference `MIT` (check succeeded).
- Created a commit containing the changes (`git commit -m "Relicense project to MIT"`) which recorded the modified files: `LICENSE`, `pyproject.toml`, `README.md`, and `vibe/README.md` (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7d6228ad883288518ad176e544c03)